### PR TITLE
Test action

### DIFF
--- a/.github/workflows/buildMLTBXTags.yml
+++ b/.github/workflows/buildMLTBXTags.yml
@@ -41,6 +41,6 @@ jobs:
       - name: Create release
         uses: ncipollo/release-action@v1
         with:
-          draft: false        
+          draft: true        
           artifacts: "release/fsda.mltbx"
           generateReleaseNotes: true

--- a/.github/workflows/buildMLTBXTags.yml
+++ b/.github/workflows/buildMLTBXTags.yml
@@ -1,6 +1,6 @@
-# This is a workflow for building the MLTBX artifact and release it on GitHub
+# This is a workflow to build toolbox MLTBX and release it on GitHub
 
-name: Build MLTBX tag triggered
+name: Tag triggered MLTBX build
 
 # Start the workflow when a tag is created.
 on:
@@ -10,8 +10,8 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "MLTBXBuild"
-  MLTBXBuildTag:
-    # The type of runner that the job will run on
+  MLTBXBuild:
+    # The type of runner that the job will run on, we use ubuntu
     runs-on: ubuntu-latest
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -24,10 +24,9 @@ jobs:
       
       - name: Create MLTBX
         uses: matlab-actions/run-command@v1
-        continue-on-error: true
+        continue-on-error: false
         if: always()
         with:
-          # command: matlab.addons.toolbox.packageToolbox("fsdaToolboxPackaging.prj", "release/fsda.mltbx")
           command: addpath("utilities_help");createToolboxMLTBX("${{  github.ref_name }}")
       
       # Save the MLTBX.

--- a/.github/workflows/buildMLTBXTags.yml
+++ b/.github/workflows/buildMLTBXTags.yml
@@ -28,7 +28,7 @@ jobs:
         continue-on-error: false
         if: always()
         with:
-          command: addpath("utilities_help");createToolboxMLTBX("${{  github.ref_name }}")
+          command: addpath("utilities_help");createToolboxMLTBX("fsdaToolboxPackaging.prj",  "${{  github.ref_name }}")
       
       # Save the MLTBX.
       - name: Save MLTBX

--- a/.github/workflows/buildMLTBXTags.yml
+++ b/.github/workflows/buildMLTBXTags.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   # This workflow contains a single job called "MLTBXBuild"
   MLTBXBuild:
-    # The type of runner that the job will run on, we use ubuntu
+    # The type of runner that the job will run on, we use Ubuntu
     runs-on: ubuntu-latest
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/buildMLTBXTags.yml
+++ b/.github/workflows/buildMLTBXTags.yml
@@ -8,7 +8,7 @@ on:
   push:
     tags:
       - '*'
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+# A workflow run consists of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "MLTBXBuild"
   MLTBXBuild:

--- a/.github/workflows/buildMLTBXTags.yml
+++ b/.github/workflows/buildMLTBXTags.yml
@@ -1,4 +1,5 @@
-# This is a workflow to build toolbox MLTBX and release it on GitHub
+# Copyright 2023 The MathWorks, Inc.
+# This is a GitHub Action workflow to build toolbox MLTBX and release it on GitHub
 
 name: Tag triggered MLTBX build
 

--- a/utilities_help/createToolboxMLTBX.m
+++ b/utilities_help/createToolboxMLTBX.m
@@ -1,20 +1,27 @@
-function createToolboxMLTBX(toolboxVersion)
-%Package toolbox as MLTBX file
-% This file is meant to run on a Linux node in GitHub Actions
-% Execute the code from project root
-% The code also assumes that there is a fsdaToolboxPackaging.prj at the
-% project root.
-% Input:
-%   toolboxVersion- string in major.minor.bugfix format
-% Copyright 2023 The MathWorks, Inc.
+function createToolboxMLTBX(prjFileName, toolboxVersion)
+%Package toolbox as MLTBX file.
+%   createToolboxMLTBX(toolboxVersion) builds the MLTBX file and saves it in the 
+%   release folder. Input toolboxVersion is a string of the form Major.Minor.Bug.Build.
 
-prjFileName = "fsdaToolboxPackaging.prj";
-packagingData = matlab.addons.toolbox.ToolboxOptions(prjFileName);
+%   Copyright 2023 The MathWorks, Inc.
+
+if isfile(prjFileName)
+    packagingData = matlab.addons.toolbox.ToolboxOptions(prjFileName);
+else
+    msg="Unable to find file " + "'" + prjFileName+ "'";
+    error(msg);
+end
+
+% Check if toolboxVersion is a string
+% if ~isstring(toolboxVersion)
+%     error("Toolbox version must be a string.");
+% end
 
 % Update the version number
 packagingData.ToolboxVersion = toolboxVersion;
 
 % Name for MLTBX file
 packagingData.OutputFile = fullfile("release", "fsda.mltbx");
+
 % Create toolbox MLTBX
 matlab.addons.toolbox.packageToolbox(packagingData);

--- a/utilities_help/createToolboxMLTBX.m
+++ b/utilities_help/createToolboxMLTBX.m
@@ -1,8 +1,8 @@
 function createToolboxMLTBX(prjFile, toolboxVersion)
 %Package toolbox as MLTBX file.
 %   createToolboxMLTBX(prjFile, toolboxVersion) builds the MLTBX file and saves 
-%   it in the release folder. Input prjFile is the file name of the toolbox
-%   packaging PRJ file and toolboxVersion is a string of the form Major.Minor.Bug.Build.
+%   it in the release folder. Input prjFile is the name of the toolbox
+%   packaging file and toolboxVersion is a string of the form Major.Minor.Bug.Build.
 
 %   Copyright 2023 The MathWorks, Inc.
 

--- a/utilities_help/createToolboxMLTBX.m
+++ b/utilities_help/createToolboxMLTBX.m
@@ -1,14 +1,15 @@
-function createToolboxMLTBX(prjFileName, toolboxVersion)
+function createToolboxMLTBX(prjFile, toolboxVersion)
 %Package toolbox as MLTBX file.
-%   createToolboxMLTBX(toolboxVersion) builds the MLTBX file and saves it in the 
-%   release folder. Input toolboxVersion is a string of the form Major.Minor.Bug.Build.
+%   createToolboxMLTBX(prjFile, toolboxVersion) builds the MLTBX file and saves 
+%   it in the release folder. Input prjFile is the file name of the toolbox
+%   packaging PRJ file and toolboxVersion is a string of the form Major.Minor.Bug.Build.
 
 %   Copyright 2023 The MathWorks, Inc.
 
-if isfile(prjFileName)
-    packagingData = matlab.addons.toolbox.ToolboxOptions(prjFileName);
+if isfile(prjFile)
+    packagingData = matlab.addons.toolbox.ToolboxOptions(prjFile);
 else
-    msg="Unable to find file " + "'" + prjFileName+ "'";
+    msg="Unable to find file " + "'" + prjFile+ "'";
     error(msg);
 end
 

--- a/utilities_help/createToolboxMLTBX.m
+++ b/utilities_help/createToolboxMLTBX.m
@@ -6,7 +6,7 @@ function createToolboxMLTBX(verNumber)
 % Input:
 %   verNumber- string in major.minor.bugfix format
 % Copyright 2023 The MathWorks, Inc.
-prjFileName=fullfile("fsdaToolboxPackaging.prj");
+prjFileName="fsdaToolboxPackaging.prj";
 toolboxOption=matlab.addons.toolbox.ToolboxOptions(prjFileName);
 
 % Update the version number

--- a/utilities_help/createToolboxMLTBX.m
+++ b/utilities_help/createToolboxMLTBX.m
@@ -7,13 +7,13 @@ function createToolboxMLTBX(verNumber)
 %   verNumber- string in major.minor.bugfix format
 % Copyright 2023 The MathWorks, Inc.
 
-prjFileName="fsdaToolboxPackaging.prj";
-toolboxOption=matlab.addons.toolbox.ToolboxOptions(prjFileName);
+prjFileName = "fsdaToolboxPackaging.prj";
+toolboxOption = matlab.addons.toolbox.ToolboxOptions(prjFileName);
 
 % Update the version number
-toolboxOption.ToolboxVersion=verNumber;
+toolboxOption.ToolboxVersion = verNumber;
 
 % Name for MLTBX file
-toolboxOption.OutputFile=fullfile("release", "fsda.mltbx");
+toolboxOption.OutputFile = fullfile("release", "fsda.mltbx");
 %Create toolbox MLTBX
 matlab.addons.toolbox.packageToolbox(toolboxOption);

--- a/utilities_help/createToolboxMLTBX.m
+++ b/utilities_help/createToolboxMLTBX.m
@@ -5,6 +5,7 @@ function createToolboxMLTBX(verNumber)
 % project root.
 % Input:
 %   verNumber- string in major.minor.bugfix format
+% Copyright 2023 The MathWorks, Inc.
 prjFileName=fullfile("fsdaToolboxPackaging.prj");
 toolboxOption=matlab.addons.toolbox.ToolboxOptions(prjFileName);
 

--- a/utilities_help/createToolboxMLTBX.m
+++ b/utilities_help/createToolboxMLTBX.m
@@ -1,4 +1,5 @@
 function createToolboxMLTBX(toolboxVersion)
+%Package toolbox as MLTBX file
 % This file is meant to run on a Linux node in GitHub Actions
 % Execute the code from project root
 % The code also assumes that there is a fsdaToolboxPackaging.prj at the
@@ -8,12 +9,12 @@ function createToolboxMLTBX(toolboxVersion)
 % Copyright 2023 The MathWorks, Inc.
 
 prjFileName = "fsdaToolboxPackaging.prj";
-toolboxOption = matlab.addons.toolbox.ToolboxOptions(prjFileName);
+packagingData = matlab.addons.toolbox.ToolboxOptions(prjFileName);
 
 % Update the version number
-toolboxOption.ToolboxVersion = toolboxVersion;
+packagingData.ToolboxVersion = toolboxVersion;
 
 % Name for MLTBX file
-toolboxOption.OutputFile = fullfile("release", "fsda.mltbx");
+packagingData.OutputFile = fullfile("release", "fsda.mltbx");
 % Create toolbox MLTBX
-matlab.addons.toolbox.packageToolbox(toolboxOption);
+matlab.addons.toolbox.packageToolbox(packagingData);

--- a/utilities_help/createToolboxMLTBX.m
+++ b/utilities_help/createToolboxMLTBX.m
@@ -15,5 +15,5 @@ toolboxOption.ToolboxVersion = verNumber;
 
 % Name for MLTBX file
 toolboxOption.OutputFile = fullfile("release", "fsda.mltbx");
-%Create toolbox MLTBX
+% Create toolbox MLTBX
 matlab.addons.toolbox.packageToolbox(toolboxOption);

--- a/utilities_help/createToolboxMLTBX.m
+++ b/utilities_help/createToolboxMLTBX.m
@@ -1,17 +1,17 @@
-function createToolboxMLTBX(verNumber)
+function createToolboxMLTBX(toolboxVersion)
 % This file is meant to run on a Linux node in GitHub Actions
 % Execute the code from project root
 % The code also assumes that there is a fsdaToolboxPackaging.prj at the
 % project root.
 % Input:
-%   verNumber- string in major.minor.bugfix format
+%   toolboxVersion- string in major.minor.bugfix format
 % Copyright 2023 The MathWorks, Inc.
 
 prjFileName = "fsdaToolboxPackaging.prj";
 toolboxOption = matlab.addons.toolbox.ToolboxOptions(prjFileName);
 
 % Update the version number
-toolboxOption.ToolboxVersion = verNumber;
+toolboxOption.ToolboxVersion = toolboxVersion;
 
 % Name for MLTBX file
 toolboxOption.OutputFile = fullfile("release", "fsda.mltbx");

--- a/utilities_help/createToolboxMLTBX.m
+++ b/utilities_help/createToolboxMLTBX.m
@@ -6,6 +6,7 @@ function createToolboxMLTBX(verNumber)
 % Input:
 %   verNumber- string in major.minor.bugfix format
 % Copyright 2023 The MathWorks, Inc.
+
 prjFileName="fsdaToolboxPackaging.prj";
 toolboxOption=matlab.addons.toolbox.ToolboxOptions(prjFileName);
 


### PR DESCRIPTION
Hi Team,
Please review the following files:
.github/workflows/buildMLTBXTags.yml
utilities_help/createToolboxMLTBX.m
The YML file implements the GH Action and the m-file creates the MLTBX.

-Bensingh

Comments by Rob:
1.	I’d suggest using fullfile, rather than assembling file paths
2.	I’d make the createFSDAToolboxActions to be a function, rather than requiring it to be changed each time.
3.	Consider dropping the .PRJ file altogether, and create the ToolboxOptions object from scratch – it’ll be easier to maintain over time.
4.	You can get the version number from the tag inside the action with the ${{  github.ref_name }} token.  You may need to strip out the “v” prefix from the tag.  See my https://github.com/mathworks/climatedatastore/blob/main/.github/workflows/release.yml
5.	I recommend that you create the release as a draft, so that you can edit release notes and other “human in the loop” things.
